### PR TITLE
different colors for patch status labels (mapping to bootstrap CSS classes)

### DIFF
--- a/pgcommitfest/commitfest/models.py
+++ b/pgcommitfest/commitfest/models.py
@@ -151,6 +151,14 @@ class PatchOnCommitFest(models.Model):
 		(STATUS_RETURNED, 'Returned with Feedback'),
 		(STATUS_REJECTED, 'Rejected'),
 	)
+	_STATUS_LABELS=(
+		(STATUS_REVIEW, 'default'),
+		(STATUS_AUTHOR, 'primary'),
+		(STATUS_COMMITTER, 'info'),
+		(STATUS_COMMITTED, 'success'),
+		(STATUS_RETURNED, 'warning'),
+		(STATUS_REJECTED, 'danger'),
+	)
 	OPEN_STATUSES=(STATUS_REVIEW, STATUS_AUTHOR, STATUS_COMMITTER)
 	OPEN_STATUS_CHOICES=[x for x in _STATUS_CHOICES if x[0] in OPEN_STATUSES]
 

--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -69,7 +69,7 @@
 {%endif%}
   <tr>
    <td><a href="{{p.id}}/">{{p}}</a></td>
-   <td><span class="label label-default">{{p.status|patchstatusstring}}</span></td>
+   <td><span class="label label-{{p.status|patchstatuslabel}}">{{p.status|patchstatusstring}}</span></td>
    <td>{{p.author_names|default:''}}</td>
    <td>{{p.reviewer_names|default:''}}</td>
    <td>{{p.committer|default:''}}</p>

--- a/pgcommitfest/commitfest/templatetags/commitfest.py
+++ b/pgcommitfest/commitfest/templatetags/commitfest.py
@@ -11,6 +11,12 @@ def patchstatusstring(value):
 	i = int(value)
 	return [v for k,v in PatchOnCommitFest._STATUS_CHOICES if k==i][0]
 
+@register.filter(name='patchstatuslabel')
+@stringfilter
+def patchstatuslabel(value):
+	i = int(value)
+	return [v for k,v in PatchOnCommitFest._STATUS_LABELS if k==i][0]
+
 @register.filter(is_safe=True)
 def label_class(value, arg):
 	return value.label_tag(attrs={'class': arg})


### PR DESCRIPTION
Trivial improvement of the CSS, using color labels for patch status labels (instead of a single grey one). Makes it easier to spot patches in particular state.